### PR TITLE
comment on statements/extension is unhandled by sqlparser

### DIFF
--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -1,7 +1,7 @@
 use crate::{config, csv::DataFrame, graph, sql};
 use sqlparser::{
     ast::{AlterTableOperation, ColumnOption, Statement, TableConstraint},
-    dialect::GenericDialect,
+    dialect::PostgreSqlDialect,
     parser::Parser,
 };
 use std::{
@@ -11,7 +11,7 @@ use std::{
 
 /// Parses SQL content and extracts table definitions.
 pub fn parse_sql(contents: &str) -> Result<Vec<DataFrame>, Box<dyn Error>> {
-    let dialect = GenericDialect {};
+    let dialect = PostgreSqlDialect {};
     let ast = Parser::parse_sql(&dialect, &contents)?;
     let mut tables = ast
         .clone()

--- a/src/tests/sql.rs
+++ b/src/tests/sql.rs
@@ -187,7 +187,6 @@ fn test_parse_sql_with_multiple_comment_on_statements() -> Result<(), Box<dyn Er
 
     let tables = parse_sql(sql)?;
 
-    // Ensure that all COMMENT ON statements are ignored, and only the table is parsed
     assert_eq!(tables.len(), 1);
     let table = &tables[0];
     assert_eq!(table.name, "users");


### PR DESCRIPTION
sqlparser only handles comment on column and comment on statement.